### PR TITLE
Fix missing RPL name mapping

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,11 +5,21 @@ let PRESETS = [];  // local presets
 
 /* Column header mapping */
 const columnMap = {
-  name: ["Nazwa produktu","Nazwa Produktu","nazwa_produktu","Nazwa"],
+  name: [
+    "Nazwa produktu",
+    "Nazwa Produktu",
+    "nazwa_produktu",
+    "Nazwa",
+    "Nazwa Produktu Leczniczego"
+  ],
   form: ["Postać farmaceutyczna","Postac farmaceutyczna","Postać","postac"],
   strength: ["Moc","Dawka","moc"],
   pack: ["Wielkość opakowania","Wielkosc opakowania","Wielkość","opakowanie"],
-  route: ["Droga podania","droga_podania"],
+  route: [
+    "Droga podania",
+    "droga_podania",
+    "Droga podania - Gatunek - Tkanka - Okres karencji"
+  ],
   mah: ["Podmiot odpowiedzialny","podmiot_odpowiedzialny"],
   ean: ["EAN","Kod EAN","ean"]
 };


### PR DESCRIPTION
## Summary
- recognize `Nazwa Produktu Leczniczego` when mapping CSV columns
- include long-form route header in column map

## Testing
- `node --check app.js`
- `python - <<'PY'
import csv
column_map = {
  'name': ["Nazwa produktu","Nazwa Produktu","nazwa_produktu","Nazwa","Nazwa Produktu Leczniczego"],
  'form': ["Postać farmaceutyczna","Postac farmaceutyczna","Postać","postac"],
  'strength': ["Moc","Dawka","moc"],
  'pack': ["Wielkość opakowania","Wielkosc opakowania","Wielkość","opakowanie"],
  'route': ["Droga podania","droga_podania","Droga podania - Gatunek - Tkanka - Okres karencji"],
  'mah': ["Podmiot odpowiedzialny","podmiot_odpowiedzialny"],
  'ean': ["EAN","Kod EAN","ean"],
}

def normalize(h):
    return (h or '').strip().replace('\n',' ').replace('\r',' ').replace('\t',' ').replace('  ',' ')

def map_row(raw):
    def get(keys):
        for k in keys:
            for hdr in raw.keys():
                if normalize(hdr).lower() == k.lower():
                    return str(raw[hdr]).strip()
        return ''
    return {
        'name': get(column_map['name'])
    }

count = 0
with open('data/rpl.csv', newline='', encoding='utf-8') as f:
    reader = csv.DictReader(f, delimiter=';')
    for row in reader:
        m = map_row(row)
        if m['name']:
            count += 1
print('mapped rows:', count)
PY`

------
https://chatgpt.com/codex/tasks/task_e_689766bbd5f8832e8fcb55e041b440ba