### PR TITLE
Add CSV parsing test and CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,16 @@
+name: test
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm install
+      - run: npm test

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "rpl-picker",
+  "version": "1.0.0",
+  "description": "RPL picker",
+  "main": "app.js",
+  "scripts": {
+    "test": "node --test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "devDependencies": {
+    "papaparse": "^5.4.1"
+  }
+}

--- a/test/fixtures/opakowanie.csv
+++ b/test/fixtures/opakowanie.csv
@@ -1,0 +1,5 @@
+Nazwa produktu,Opakowanie
+"Produkt A","butelka 100 ml
+karton"
+"Produkt B","słoik 50 g
++ łyżeczka"

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -1,0 +1,23 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const Papa = require('papaparse');
+
+test('parses CSV with multiline Opakowanie column', () => {
+  const csvPath = path.join(__dirname, 'fixtures', 'opakowanie.csv');
+  const csv = fs.readFileSync(csvPath, 'utf8');
+  const result = Papa.parse(csv, {
+    header: true,
+    skipEmptyLines: true
+  });
+  assert.equal(result.data.length, 2);
+  assert.deepEqual(result.data[0], {
+    'Nazwa produktu': 'Produkt A',
+    'Opakowanie': 'butelka 100 ml\nkarton'
+  });
+  assert.deepEqual(result.data[1], {
+    'Nazwa produktu': 'Produkt B',
+    'Opakowanie': 'słoik 50 g\n+ łyżeczka'
+  });
+});


### PR DESCRIPTION
## Summary
- set up basic Node test infrastructure with Papa.parse
- include fixture CSV with multiline "Opakowanie" column
- add GitHub Actions workflow to run tests

## Testing
- `npm test` *(fails: Cannot find module 'papaparse')*

------
https://chatgpt.com/codex/tasks/task_e_68976d8ce594832eb7b6ed027a1e717c