### PR TITLE
Handle semicolon-delimited RPL CSV files

### DIFF
--- a/app.js
+++ b/app.js
@@ -99,7 +99,9 @@ async function loadFromFile(file) {
   } else {
     Papa.parse(file, {
       header: true,
-      skipEmptyLines: true,
+      delimiter: ';',
+      newline: '\r\n',
+      skipEmptyLines: 'greedy',
       complete: (res) => {
         ROWS = res.data.map(mapRow).filter(r => r.name);
         EL("status").textContent = `Załadowano wierszy: ${ROWS.length}`;
@@ -119,7 +121,9 @@ EL("btnLoadRepo").addEventListener("click", async () => {
     const text = await res.text();
     Papa.parse(text, {
       header: true,
-      skipEmptyLines: true,
+      delimiter: ';',
+      newline: '\r\n',
+      skipEmptyLines: 'greedy',
       complete: (r) => {
         ROWS = r.data.map(mapRow).filter(r => r.name);
         EL("status").textContent = `Załadowano wierszy: ${ROWS.length}`;


### PR DESCRIPTION
## Summary
- configure Papa.parse to read RPL CSVs with `;` delimiter, CRLF newlines, and greedy empty-line skipping
- apply the same options when loading CSV from repo

## Testing
- `node -c app.js`
- `npm test` *(fails: package.json not found)*
- `python - <<'PY' ...`

------
https://chatgpt.com/codex/tasks/task_e_68976dadbfd0832e950e45a0c666f873