### PR TITLE
Add CSV trimming and integrity check

### DIFF
--- a/.github/workflows/fetch-rpl.yml
+++ b/.github/workflows/fetch-rpl.yml
@@ -16,18 +16,33 @@ jobs:
       - name: Ensure data dir
         run: mkdir -p data
 
-      - name: Download latest CSV (RPL)
+      - name: Install dependencies
+        run: npm install
+
+      - name: Download latest CSV (RPL) and trim
         run: |
+          set -e
           curl -fL --retry 3 --retry-delay 10 \
             "https://rejestrymedyczne.ezdrowie.gov.pl/api/rpl/medicinal-products/public-pl-report/get-csv" \
-            -o data/rpl.csv
+            -o data/rpl-full.csv.new
+          if [ -f data/rpl-full.csv ]; then
+            old_md5=$(md5sum data/rpl-full.csv | cut -d' ' -f1)
+            new_md5=$(md5sum data/rpl-full.csv.new | cut -d' ' -f1)
+            if [ "$old_md5" = "$new_md5" ]; then
+              echo "No changes in downloaded file"
+              rm data/rpl-full.csv.new
+              exit 0
+            fi
+          fi
+          mv data/rpl-full.csv.new data/rpl-full.csv
+          node scripts/trim-rpl.js data/rpl-full.csv data/rpl.csv
 
       - name: Commit if changed
         run: |
           if [ -n "$(git status --porcelain)" ]; then
             git config user.name "github-actions[bot]"
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git add data/rpl.csv
+            git add data/rpl.csv data/rpl-full.csv
             git commit -m "chore: update RPL CSV $(date -u +'%Y-%m-%d')"
             git push
           else

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Strona statyczna do wybierania produktów leczniczych z Rejestru Produktów Lecz
 - Codziennie o 06:00 UTC workflow pobiera CSV z RPL:
   - **CSV (pełny raport):**
     `https://rejestrymedyczne.ezdrowie.gov.pl/api/rpl/medicinal-products/public-pl-report/get-csv`
+  - Po pobraniu tworzona jest wersja skrócona (`data/rpl.csv`) zawierająca tylko kolumny potrzebne aplikacji.
 
   Alternatywnie dostępny jest też zestaw w portalu Otwarte Dane (dane.gov.pl), ale w repo domyślnie używamy bezpośredniego CSV CeZ.
 
@@ -22,7 +23,7 @@ Strona statyczna do wybierania produktów leczniczych z Rejestru Produktów Lecz
 3. Po chwili strona będzie pod adresem `https://<twoje_konto>.github.io/rpl-picker/`
 
 ## Jak to działa (front)
-- Użytkownik może **wczytać lokalny plik CSV/XLSX** (pełna prywatność) **lub** kliknąć „Wczytaj CSV z repozytorium” — wtedy strona pobierze `data/rpl.csv` z tego repo (zaktualizowany przez workflow).
+- Użytkownik może **wczytać lokalny plik CSV/XLSX** (pełna prywatność) **lub** kliknąć „Wczytaj CSV z repozytorium” — wtedy strona pobierze skrócony plik `data/rpl.csv` z tego repo (zaktualizowany przez workflow).
 - Wyszukiwanie po nazwie + wybór mocy/opakowania na podstawie realnych kombinacji z CSV.
 - Lista wybranych + **presety** zapisywane lokalnie (`localStorage`).
 - **PDF** generowany w przeglądarce (jsPDF).
@@ -30,7 +31,8 @@ Strona statyczna do wybierania produktów leczniczych z Rejestru Produktów Lecz
 ## Pliki
 - `index.html` — strona główna (React z CDN, bez budowania).
 - `app.js` — logika (parsowanie CSV `Papa.parse`, PDF `jsPDF`).
-- `data/rpl.csv` — aktualny CSV (automatycznie aktualizowany; może być nieobecny zaraz po klonie, pojawi się po pierwszym workflow).
+- `data/rpl.csv` — skrócony CSV z potrzebnymi kolumnami (automatycznie aktualizowany; może być nieobecny zaraz po klonie, pojawi się po pierwszym workflow).
+`data/rpl-full.csv` — pełny CSV pobrany z API (dla pełnego wglądu, nieużywany przez aplikację; może być nieobecny zaraz po klonie, pojawi się po pierwszym workflow).
 - `.github/workflows/fetch-rpl.yml` — pobieranie CSV codziennie.
 - `.nojekyll` — dla GitHub Pages.
 - `LICENSE` — MIT.

--- a/scripts/trim-rpl.js
+++ b/scripts/trim-rpl.js
@@ -1,0 +1,44 @@
+const fs = require('fs');
+const Papa = require('papaparse');
+
+const input = process.argv[2];
+const output = process.argv[3];
+if (!input || !output) {
+  console.error('Usage: node trim-rpl.js <input.csv> <output.csv>');
+  process.exit(1);
+}
+
+const wanted = [
+  'Nazwa Produktu Leczniczego',
+  'Nazwa powszechnie stosowana',
+  'Rodzaj preparatu',
+  'Zakaz stosowania u zwierząt',
+  'Nazwa poprzednia produktu',
+  'Droga podania - Gatunek - Tkanka - Okres karencji',
+  'Moc',
+  'Postać farmaceutyczna',
+  'Opakowanie'
+];
+
+const csv = fs.readFileSync(input, 'utf8');
+const parsed = Papa.parse(csv, {
+  header: true,
+  delimiter: ';',
+  newline: '\r\n',
+  skipEmptyLines: 'greedy'
+});
+
+const trimmed = parsed.data.map(row => {
+  const out = {};
+  for (const col of wanted) {
+    out[col] = row[col] || '';
+  }
+  return out;
+});
+
+const outCsv = Papa.unparse(trimmed, {
+  columns: wanted,
+  delimiter: ';',
+  newline: '\r\n'
+});
+fs.writeFileSync(output, outCsv);


### PR DESCRIPTION
## Summary
- add script to reduce CSV to necessary columns
- update workflow to trim file and skip identical downloads via MD5
- document new short/full CSV files

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/papaparse)*
- `npm test` *(fails: test/parse.test.js – test failed)*

------
https://chatgpt.com/codex/tasks/task_e_689777a9cbcc832e85339c6e29ebb896